### PR TITLE
update compiler version and remove deprecated entities

### DIFF
--- a/contracts/EthereumDIDRegistry.sol
+++ b/contracts/EthereumDIDRegistry.sol
@@ -65,7 +65,7 @@ contract EthereumDIDRegistry {
   }
 
   function changeOwnerSigned(address identity, uint8 sigV, bytes32 sigR, bytes32 sigS, address newOwner) public {
-    bytes32 hash = keccak256(abi.encode(bytes1(0x19), bytes1(0), this, nonce[identityOwner(identity)], identity, "changeOwner", newOwner));
+    bytes32 hash = keccak256(abi.encodePacked(bytes1(0x19), bytes1(0), this, nonce[identityOwner(identity)], identity, "changeOwner", newOwner));
     changeOwner(identity, checkSignature(identity, sigV, sigR, sigS, hash), newOwner);
   }
 
@@ -80,7 +80,7 @@ contract EthereumDIDRegistry {
   }
 
   function addDelegateSigned(address identity, uint8 sigV, bytes32 sigR, bytes32 sigS, bytes32 delegateType, address delegate, uint validity) public {
-    bytes32 hash = keccak256(abi.encode(bytes1(0x19), bytes1(0), this, nonce[identityOwner(identity)], identity, "addDelegate", delegateType, delegate, validity));
+    bytes32 hash = keccak256(abi.encodePacked(bytes1(0x19), bytes1(0), this, nonce[identityOwner(identity)], identity, "addDelegate", delegateType, delegate, validity));
     addDelegate(identity, checkSignature(identity, sigV, sigR, sigS, hash), delegateType, delegate, validity);
   }
 
@@ -95,7 +95,7 @@ contract EthereumDIDRegistry {
   }
 
   function revokeDelegateSigned(address identity, uint8 sigV, bytes32 sigR, bytes32 sigS, bytes32 delegateType, address delegate) public {
-    bytes32 hash = keccak256(abi.encode(bytes1(0x19), bytes1(0), this, nonce[identityOwner(identity)], identity, "revokeDelegate", delegateType, delegate));
+    bytes32 hash = keccak256(abi.encodePacked(bytes1(0x19), bytes1(0), this, nonce[identityOwner(identity)], identity, "revokeDelegate", delegateType, delegate));
     revokeDelegate(identity, checkSignature(identity, sigV, sigR, sigS, hash), delegateType, delegate);
   }
 
@@ -109,7 +109,7 @@ contract EthereumDIDRegistry {
   }
 
   function setAttributeSigned(address identity, uint8 sigV, bytes32 sigR, bytes32 sigS, bytes32 name, bytes memory value, uint validity) public {
-    bytes32 hash = keccak256(abi.encode(bytes1(0x19), bytes1(0), this, nonce[identityOwner(identity)], identity, "setAttribute", name, value, validity));
+    bytes32 hash = keccak256(abi.encodePacked(bytes1(0x19), bytes1(0), this, nonce[identityOwner(identity)], identity, "setAttribute", name, value, validity));
     setAttribute(identity, checkSignature(identity, sigV, sigR, sigS, hash), name, value, validity);
   }
 
@@ -123,7 +123,7 @@ contract EthereumDIDRegistry {
   }
 
  function revokeAttributeSigned(address identity, uint8 sigV, bytes32 sigR, bytes32 sigS, bytes32 name, bytes memory value) public {
-    bytes32 hash = keccak256(abi.encode(bytes1(0x19), bytes1(0), this, nonce[identityOwner(identity)], identity, "revokeAttribute", name, value)); 
+    bytes32 hash = keccak256(abi.encodePacked(bytes1(0x19), bytes1(0), this, nonce[identityOwner(identity)], identity, "revokeAttribute", name, value)); 
     revokeAttribute(identity, checkSignature(identity, sigV, sigR, sigS, hash), name, value);
   }
 

--- a/contracts/EthereumDIDRegistry.sol
+++ b/contracts/EthereumDIDRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.4;
+pragma solidity ^0.8.6;
 
 contract EthereumDIDRegistry {
 
@@ -36,7 +36,7 @@ contract EthereumDIDRegistry {
 
   function identityOwner(address identity) public view returns(address) {
      address owner = owners[identity];
-     if (owner != 0x0) {
+     if (owner != 0x0000000000000000000000000000000000000000) {
        return owner;
      }
      return identity;
@@ -50,8 +50,8 @@ contract EthereumDIDRegistry {
   }
 
   function validDelegate(address identity, bytes32 delegateType, address delegate) public view returns(bool) {
-    uint validity = delegates[identity][keccak256(delegateType)][delegate];
-    return (validity > now);
+    uint validity = delegates[identity][keccak256(abi.encode(delegateType))][delegate];
+    return (validity > block.timestamp);
   }
 
   function changeOwner(address identity, address actor, address newOwner) internal onlyOwner(identity, actor) {
@@ -65,13 +65,13 @@ contract EthereumDIDRegistry {
   }
 
   function changeOwnerSigned(address identity, uint8 sigV, bytes32 sigR, bytes32 sigS, address newOwner) public {
-    bytes32 hash = keccak256(byte(0x19), byte(0), this, nonce[identityOwner(identity)], identity, "changeOwner", newOwner);
+    bytes32 hash = keccak256(abi.encode(bytes1(0x19), bytes1(0), this, nonce[identityOwner(identity)], identity, "changeOwner", newOwner));
     changeOwner(identity, checkSignature(identity, sigV, sigR, sigS, hash), newOwner);
   }
 
   function addDelegate(address identity, address actor, bytes32 delegateType, address delegate, uint validity) internal onlyOwner(identity, actor) {
-    delegates[identity][keccak256(delegateType)][delegate] = now + validity;
-    emit DIDDelegateChanged(identity, delegateType, delegate, now + validity, changed[identity]);
+    delegates[identity][keccak256(abi.encode(delegateType))][delegate] = block.timestamp + validity;
+    emit DIDDelegateChanged(identity, delegateType, delegate, block.timestamp + validity, changed[identity]);
     changed[identity] = block.number;
   }
 
@@ -80,13 +80,13 @@ contract EthereumDIDRegistry {
   }
 
   function addDelegateSigned(address identity, uint8 sigV, bytes32 sigR, bytes32 sigS, bytes32 delegateType, address delegate, uint validity) public {
-    bytes32 hash = keccak256(byte(0x19), byte(0), this, nonce[identityOwner(identity)], identity, "addDelegate", delegateType, delegate, validity);
+    bytes32 hash = keccak256(abi.encode(bytes1(0x19), bytes1(0), this, nonce[identityOwner(identity)], identity, "addDelegate", delegateType, delegate, validity));
     addDelegate(identity, checkSignature(identity, sigV, sigR, sigS, hash), delegateType, delegate, validity);
   }
 
   function revokeDelegate(address identity, address actor, bytes32 delegateType, address delegate) internal onlyOwner(identity, actor) {
-    delegates[identity][keccak256(delegateType)][delegate] = now;
-    emit DIDDelegateChanged(identity, delegateType, delegate, now, changed[identity]);
+    delegates[identity][keccak256(abi.encode(delegateType))][delegate] = block.timestamp;
+    emit DIDDelegateChanged(identity, delegateType, delegate, block.timestamp, changed[identity]);
     changed[identity] = block.number;
   }
 
@@ -95,35 +95,35 @@ contract EthereumDIDRegistry {
   }
 
   function revokeDelegateSigned(address identity, uint8 sigV, bytes32 sigR, bytes32 sigS, bytes32 delegateType, address delegate) public {
-    bytes32 hash = keccak256(byte(0x19), byte(0), this, nonce[identityOwner(identity)], identity, "revokeDelegate", delegateType, delegate);
+    bytes32 hash = keccak256(abi.encode(bytes1(0x19), bytes1(0), this, nonce[identityOwner(identity)], identity, "revokeDelegate", delegateType, delegate));
     revokeDelegate(identity, checkSignature(identity, sigV, sigR, sigS, hash), delegateType, delegate);
   }
 
-  function setAttribute(address identity, address actor, bytes32 name, bytes value, uint validity ) internal onlyOwner(identity, actor) {
-    emit DIDAttributeChanged(identity, name, value, now + validity, changed[identity]);
+  function setAttribute(address identity, address actor, bytes32 name, bytes memory value, uint validity ) internal onlyOwner(identity, actor) {
+    emit DIDAttributeChanged(identity, name, value, block.timestamp + validity, changed[identity]);
     changed[identity] = block.number;
   }
 
-  function setAttribute(address identity, bytes32 name, bytes value, uint validity) public {
+  function setAttribute(address identity, bytes32 name, bytes memory value, uint validity) public {
     setAttribute(identity, msg.sender, name, value, validity);
   }
 
-  function setAttributeSigned(address identity, uint8 sigV, bytes32 sigR, bytes32 sigS, bytes32 name, bytes value, uint validity) public {
-    bytes32 hash = keccak256(byte(0x19), byte(0), this, nonce[identityOwner(identity)], identity, "setAttribute", name, value, validity);
+  function setAttributeSigned(address identity, uint8 sigV, bytes32 sigR, bytes32 sigS, bytes32 name, bytes memory value, uint validity) public {
+    bytes32 hash = keccak256(abi.encode(bytes1(0x19), bytes1(0), this, nonce[identityOwner(identity)], identity, "setAttribute", name, value, validity));
     setAttribute(identity, checkSignature(identity, sigV, sigR, sigS, hash), name, value, validity);
   }
 
-  function revokeAttribute(address identity, address actor, bytes32 name, bytes value ) internal onlyOwner(identity, actor) {
+  function revokeAttribute(address identity, address actor, bytes32 name, bytes memory value ) internal onlyOwner(identity, actor) {
     emit DIDAttributeChanged(identity, name, value, 0, changed[identity]);
     changed[identity] = block.number;
   }
 
-  function revokeAttribute(address identity, bytes32 name, bytes value) public {
+  function revokeAttribute(address identity, bytes32 name, bytes memory value) public {
     revokeAttribute(identity, msg.sender, name, value);
   }
 
- function revokeAttributeSigned(address identity, uint8 sigV, bytes32 sigR, bytes32 sigS, bytes32 name, bytes value) public {
-    bytes32 hash = keccak256(byte(0x19), byte(0), this, nonce[identityOwner(identity)], identity, "revokeAttribute", name, value); 
+ function revokeAttributeSigned(address identity, uint8 sigV, bytes32 sigR, bytes32 sigS, bytes32 name, bytes memory value) public {
+    bytes32 hash = keccak256(abi.encode(bytes1(0x19), bytes1(0), this, nonce[identityOwner(identity)], identity, "revokeAttribute", name, value)); 
     revokeAttribute(identity, checkSignature(identity, sigV, sigR, sigS, hash), name, value);
   }
 


### PR DESCRIPTION
This PR contains changes : 

1. Upgrade compiler version
2. Replaces `now` with `block.timestamp`
3. Replaces `byte` with `bytes1`
4. Updates `keccak256` implementation to one parameter implementation (latest version)
5. Updates `0x0` address to full length address